### PR TITLE
turned off sendfile for nginx to fix VM file sync issues

### DIFF
--- a/tools/vagrant_provision.sh
+++ b/tools/vagrant_provision.sh
@@ -12,6 +12,7 @@ sudo apt-get install --yes -q nginx
 # configure nginx
 sudo rm /etc/nginx/sites-enabled/default
 sudo ln -s /vagrant/conf/nginx-vhost-vagrant.conf /etc/nginx/sites-enabled/mmp 
+sudo sed -i 's/sendfile on/sendfile off/g' /etc/nginx/nginx.conf
 sudo service nginx restart
 
 # configure app    


### PR DESCRIPTION
Fixes an issue I forgot nginx has while running in VM's with non-native mounted file systems.

If you have already provisioned your vagrant, save yourself some hair and run this command in the VM:

`sudo sed -i 's/sendfile on/sendfile off/g' /etc/nginx/nginx.conf`
