### PR TITLE
profile password reset actually calls Service Method

### DIFF
--- a/app/services/UserService.php
+++ b/app/services/UserService.php
@@ -34,6 +34,10 @@ class UserService extends Service implements IUserService1 {
     }
 
     public function UpdatePassword($userid, $password) {
+        if (CurrentUser::getIdentity() != $userid || CurrentUser::hasAnyPermissions("administrator") != true) {
+            return;
+        }
+
         $user = $this->GetUser($userid);
 
         if(is_null($user)) return;

--- a/web/providers/user.js
+++ b/web/providers/user.js
@@ -60,6 +60,9 @@ angular
                     .then(function(response) {
                         return response.data;
                     });
+            },
+            UpdatePassword: function(userid, password) {
+                return $http.post("/services/web/UserService1.svc/UpdatePassword", {userid: userid, password: password});
             }
         };
     }]);

--- a/web/user/profile/profile.html
+++ b/web/user/profile/profile.html
@@ -255,10 +255,6 @@
             </div>
             <form name="changePasswordForm" ng-submit="changePassword(changePasswordForm.$valid)" novalidate>
                 <div class="modal-body">
-                    <div class="form-group" ng-class="{ 'has-error' : changePasswordForm.currentPassword.$invalid && !changePasswordForm.currentPassword.$pristine }">
-                        <input class="form-control" type="password" placeholder="Current Password" name="currentPassword" ng-model="currentPassword" required>
-                        <p class="help-block" ng-show="changePasswordForm.currentPassword.$invalid && !changePasswordForm.currentPassword.$pristine">Incorrect password</p>
-                    </div>
                     <div class="form-group" ng-class="{ 'has-error' : changePasswordForm.newPassword.$invalid && !changePasswordForm.newPassword.$pristine }">
                         <input class="form-control" type="password" placeholder="New Password" name="newPassword" ng-model="newPassword" ng-minlength="4" required ng-change="comparePasswords()">
                         <p class="help-block" ng-show="changePasswordForm.newPassword.$error.minlength">Passwords must be at least 4 characters long</p>

--- a/web/user/profile/profile.js
+++ b/web/user/profile/profile.js
@@ -22,9 +22,13 @@ angular
                     };
 
                     $scope.changePassword = function(isValid) {
-                        alert("could prob change the password I guess");
-
-                        $scope.resetPasswordForm();
+                        UserService1.UpdatePassword($scope.currentUser.id, $scope.newPassword).then(function(response) {
+                            alert('Password was changed successfully.');
+                            $('#passwordChange').modal('hide'); // forgive me spaghetti monster, for I have sinned. I have done view logic in my controller.
+                            $scope.resetPasswordForm();
+                        }, function(err) {
+                            alert('We encountered an error trying to update your password.');
+                        });
                     };
 
                     $scope.comparePasswords = function() {
@@ -33,7 +37,6 @@ angular
 
                     $scope.resetPasswordForm = function() {
                         $scope.changePasswordForm.$setPristine();
-                        $scope.currentPassword = "";
                         $scope.newPassword = "";
                         $scope.rePassword = "";
                     };


### PR DESCRIPTION
This works, but I feel like I have done terrible things to make it work.

As per the slack discussion earlier today, I removed the "matching" old password requirement to update a password. This matches the User Service method more closely, so win!

I haven't a clue how the permissions work, so I doubled down in the UserService to make sure we should be UpdatedPasswords, potentially completely redundant.

And my last sin, I closed the modal from the ViewController. Looking at how models are handled in other places, it feels like we need a directive to handle this logic in a bad way. We should not be touching view logic or generating models in controllers. My front-end engineer would smack me for what I have done in this commit.

All praise the mighty spaghetti monster!
