### PR TITLE
exit handlers if ended

### DIFF
--- a/vhs/web/HttpServer.php
+++ b/vhs/web/HttpServer.php
@@ -63,6 +63,8 @@ class HttpServer {
         /** @var IHttpModule $module */
         $index = 0;
         foreach($this->modules as $module) {
+            if($this->endset) break;
+
             try {
                 $module->handle($this);
             } catch(\Exception $ex) {


### PR DESCRIPTION
After the IPN payment gateway was run and finished it would try to run the service handler module and fail because it couldn't find an endpoint and despite the IPN running fine it would always generate an exception.

The HttpServer->handle should iterate modules until a server->end is called then stop going through the handlers and start finishing the request.