### PR TITLE
ensure privs are cleared

### DIFF
--- a/app/security/oauth/OAuthHelper.php
+++ b/app/security/oauth/OAuthHelper.php
@@ -67,6 +67,8 @@ class OAuthHelper
         $key->notes = $notes;
 
         $key->privileges->clear();
+        $key->save();
+
         $key->privileges->add(Privilege::findByCode('inherit'));
 
         $key->save();


### PR DESCRIPTION
DomainCollection->clear() doesn't delete immediately in the DB and if you clear then re-add items that may have been there before, they could conflict on children during the save.

This fix sorta feels like a hack.. generally you should think that ->clear() ->add() ->save() would work and you don't have to do ->clear() ->save() ->add() ->save() to avoid conflicts or re-adding items.

Child relationships would have to be updated to handle their existing items and which to remove or add or leave as part of a put type operation but at this time it is not supported to behave this way. It's a bit of an edge case... creating an issue for this: https://github.com/vhs/nomos/issues/178