### PR TITLE
add rabbitmq support for monitors to announce

### DIFF
--- a/app/app.php
+++ b/app/app.php
@@ -33,6 +33,7 @@ $serverLog = new \vhs\loggers\FileLogger(dirname(__FILE__) . "/../logs/server.lo
 
 \app\monitors\PaypalIpnMonitor::getInstance()->Init($serverLog);
 \app\monitors\PaymentMonitor::getInstance()->Init($serverLog);
+\app\monitors\AccessLogMonitor::getInstance()->Init($serverLog);
 
 \app\security\oauth\modules\OAuthHandlerModule::register(new \app\security\oauth\modules\GithubOAuthHandler());
 \app\security\oauth\modules\OAuthHandlerModule::register(new \app\security\oauth\modules\GoogleOAuthHandler());

--- a/app/include.php
+++ b/app/include.php
@@ -29,6 +29,25 @@ $mySqlEngine->setLogger($sqlLog);
 
 \vhs\database\Database::setEngine($mySqlEngine);
 
+$rabbitLog = (DEBUG) ? new \vhs\loggers\FileLogger(dirname(__FILE__) . "/../logs/rabbit.log") : new \vhs\loggers\SilentLogger();
+
+\vhs\messaging\MessageQueue::setLogger($rabbitLog);
+\vhs\messaging\MessageQueue::setRethrow(true);
+
+$rabbitMQ = new \vhs\messaging\engines\RabbitMQ\RabbitMQEngine(
+    new \vhs\messaging\engines\RabbitMQ\RabbitMQConnectionInfo(
+        RABBITMQ_HOST,
+        RABBITMQ_PORT,
+        RABBITMQ_USER,
+        RABBITMQ_PASSWORD,
+        RABBITMQ_VHOST
+    )
+);
+
+$rabbitMQ->setLogger($rabbitLog);
+
+\vhs\messaging\MessageQueue::setEngine($rabbitMQ);
+
 \vhs\SplClassLoader::getInstance()->add(new \vhs\SplClassLoaderItem('app', ROOT_NAMESPACE_PATH));
 
 $serviceLog = (DEBUG) ? new \vhs\loggers\FileLogger(dirname(__FILE__) . "/service.log") : new \vhs\loggers\SilentLogger();

--- a/app/monitors/AccessLogMonitor.php
+++ b/app/monitors/AccessLogMonitor.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Thomas
+ * Date: 3/3/2016
+ * Time: 5:17 PM
+ */
+
+namespace app\monitors;
+
+
+use app\domain\AccessLog;
+use app\domain\User;
+use Aws\Sns\MessageValidator\Message;
+use vhs\Logger;
+use vhs\messaging\MessageQueue;
+use vhs\monitors\Monitor;
+
+class AccessLogMonitor extends Monitor
+{
+
+    public function Init(Logger &$logger = null)
+    {
+        AccessLog::onAnyCreated([$this, "accessed"]);
+    }
+
+    public function accessed($args) {
+        //$entry = AccessLog::find($args[0]->id);
+
+        $retval = array();
+
+        $retval["type"] = $args[0]->type;
+        $retval["authorized"] = $args[0]->authorized;
+        $retval["time"] = $args[0]->time;
+        $retval["username"] = "unknown";
+
+        if (!is_null($args[0]->userid)) {
+            $user = User::find($args[0]->userid);
+
+            $retval["username"] = $user->username;
+        }
+
+        MessageQueue::publish("accessLog", "created", json_encode($retval));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
   "require": {
 	  "aws/aws-sdk-php": "2.*",
     "nicmart/string-template": "~0.1",
-    "league/oauth2-client": "0.10.*"
+    "league/oauth2-client": "0.10.*",
+    "php-amqplib/php-amqplib": "2.5.*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.4"

--- a/conf/config.ini.php.template
+++ b/conf/config.ini.php.template
@@ -30,6 +30,12 @@
      define('OAUTH_GOOGLE_CLIENT', '');
      define('OAUTH_GOOGLE_SECRET', '');
 
+     define('RABBITMQ_HOST', 'localhost');
+     define('RABBITMQ_PORT', '5672');
+     define('RABBITMQ_USER', 'nomos');
+     define('RABBITMQ_PASSWORD', 'password');
+     define('RABBITMQ_VHOST', 'nomos');
+
 	/** 
 	* Show MySql Errors. 
 	* Not recomended for live site. true/false 

--- a/tools/vagrant_provision.sh
+++ b/tools/vagrant_provision.sh
@@ -55,3 +55,19 @@ chmod 777 /vagrant/app/server.log
 
 cd /vagrant/tools
 php migrate.php
+
+# rabbitmq
+
+
+echo "deb http://www.rabbitmq.com/debian/ testing main" | sudo tee -a /etc/apt/sources.list
+wget https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+sudo apt-key add rabbitmq-signing-key-public.asc
+sudo apt-get update
+sudo apt-get install --yes -q rabbitmq-server
+sudo rabbitmq-plugins enable rabbitmq_management
+sudo rabbitmqctl add_user vhs password
+sudo rabbitmqctl set_user_tags vhs administrator
+sudo rabbitmqctl add_user nomos password
+sudo rabbitmqctl add_vhost nomos
+sudo rabbitmqctl set_permissions -p nomos vhs ".*" ".*" ".*"
+sudo rabbitmqctl set_permissions -p nomos nomos ".*" ".*" ".*"

--- a/vhs/messaging/ConnectionInfo.php
+++ b/vhs/messaging/ConnectionInfo.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Thomas
+ * Date: 3/3/2016
+ * Time: 5:36 PM
+ */
+
+namespace vhs\messaging;
+
+
+abstract class ConnectionInfo {
+    abstract public function getDetails();
+
+    public function __toString() {
+        return var_export($this->getDetails(), true);
+    }
+}

--- a/vhs/messaging/Engine.php
+++ b/vhs/messaging/Engine.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Thomas
+ * Date: 3/3/2016
+ * Time: 5:26 PM
+ */
+
+namespace vhs\messaging;
+
+
+use vhs\Logger;
+
+abstract class Engine implements IMessagingInterface {
+
+    abstract public function setLogger(Logger $logger);
+    abstract public function connect();
+    abstract public function disconnect();
+
+    public function __toString() {
+        return get_called_class();
+    }
+}

--- a/vhs/messaging/IMessagingInterface.php
+++ b/vhs/messaging/IMessagingInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Thomas
+ * Date: 3/3/2016
+ * Time: 5:25 PM
+ */
+
+namespace vhs\messaging;
+
+
+interface IMessagingInterface
+{
+    public function publish($channel, $queue, $message);
+    public function consume($channel, $queue, callable $callback);
+    public function hasCallbacks($channel);
+    public function wait($channel);
+}

--- a/vhs/messaging/MessageQueue.php
+++ b/vhs/messaging/MessageQueue.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Thomas
+ * Date: 3/3/2016
+ * Time: 5:21 PM
+ */
+
+namespace vhs\messaging;
+
+
+use vhs\messaging\Engine;
+use vhs\Logger;
+use vhs\loggers\SilentLogger;
+use vhs\Singleton;
+//TODO do this stuff in a thread prob, or at least in a non-blocking way maybe?
+class MessageQueue extends Singleton
+{
+    /** @var bool */
+    private $rethrow;
+
+    /** @var Logger */
+    private $logger;
+
+    /** @var Engine */
+    private $engine;
+
+    protected function __construct() {
+        $this->setLoggerInternal(new SilentLogger());
+        $this->setRethrowInternal(true);
+    }
+
+    public function __destruct() {
+        $this->engine->disconnect();
+    }
+
+    private function handleException($exception) {
+        $this->logger->log($exception);
+
+        if($this->rethrow)
+            throw $exception;
+    }
+
+    private function invokeEngine(callable $func) {
+        try {
+            $this->engine->connect();
+        } catch(\Exception $ex) {
+            $this->handleException($ex);
+        }
+
+        $retval = null;
+
+        try {
+            $retval = $func();
+        } catch(\Exception $ex) {
+            $this->handleException($ex);
+        }
+
+        return $retval;
+    }
+
+    private function setRethrowInternal($rethrow) {
+        $this->rethrow = $rethrow;
+    }
+
+    private function setLoggerInternal(Logger $logger) {
+        $this->logger = $logger;
+    }
+
+    private function setEngineInternal(Engine $engine) {
+        if(!is_null($this->engine))
+            $this->engine->disconnect();
+
+        $this->engine = $engine;
+    }
+
+    public static function setRethrow($rethrow) {
+        /** @var MessageQueue $mq */
+        $mq = self::getInstance();
+
+        $mq->setRethrowInternal($rethrow);
+    }
+
+    public static function setLogger(Logger $logger) {
+        /** @var MessageQueue $mq */
+        $mq = self::getInstance();
+
+        $mq->setLoggerInternal($logger);
+    }
+
+    public static function setEngine(Engine $engine) {
+        /** @var MessageQueue $mq */
+        $mq = self::getInstance();
+
+        $mq->setEngineInternal($engine);
+    }
+
+    public static function publish($channel, $queue, $message) {
+        /** @var MessageQueue $mq */
+        $mq = self::getInstance();
+
+        $mq->invokeEngine(function() use ($mq, $channel, $queue, $message) {
+            return $mq->engine->publish($channel, $queue, $message);
+        });
+    }
+
+    public static function consume($channel, $queue, callable $callback) {
+        /** @var MessageQueue $mq */
+        $mq = self::getInstance();
+
+        $mq->invokeEngine(function() use ($mq, $channel, $queue, $callback) {
+            return $mq->engine->consume($channel, $queue, $callback);
+        });
+    }
+}

--- a/vhs/messaging/engines/RabbitMQ/RabbitMQConnectionInfo.php
+++ b/vhs/messaging/engines/RabbitMQ/RabbitMQConnectionInfo.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Thomas
+ * Date: 3/3/2016
+ * Time: 5:36 PM
+ */
+
+namespace vhs\messaging\engines\RabbitMQ;
+
+
+use vhs\messaging\ConnectionInfo;
+
+class RabbitMQConnectionInfo extends ConnectionInfo
+{
+    private $host;
+    private $port;
+    private $username;
+    private $password;
+    private $vhost;
+
+    public function __construct($host, $port, $username, $password, $vhost = null) {
+        $this->host = $host;
+        $this->port = $port;
+        $this->username = $username;
+        $this->password = $password;
+        $this->vhost = $vhost;
+
+        //TODO throw argument exceptions here if shit is rotten
+    }
+
+    public function getDetails() {
+        return array(
+            "host" => $this->host,
+            "port" => $this->port,
+            "username" => $this->username,
+            "password" => $this->password,
+            "vhost" => $this->vhost
+        );
+    }
+
+    public function getHost() { return $this->host; }
+    public function getPort() { return $this->port; }
+    public function getUsername() { return $this->username; }
+    public function getPassword() { return $this->password; }
+    public function getVHost() { return $this->vhost; }
+}

--- a/vhs/messaging/engines/RabbitMQ/RabbitMQEngine.php
+++ b/vhs/messaging/engines/RabbitMQ/RabbitMQEngine.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Thomas
+ * Date: 3/3/2016
+ * Time: 5:27 PM
+ */
+
+namespace vhs\messaging\engines\RabbitMQ;
+
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+use vhs\loggers\SilentLogger;
+use vhs\messaging\Engine;
+use vhs\Logger;
+use vhs\messaging\engines\RabbitMQ\RabbitMQConnectionInfo;
+
+class RabbitMQEngine extends Engine
+{
+    private $info;
+    /** @var AMQPChannel[] */
+    private $channels;
+    private $logger;
+
+    /** @var AMQPStreamConnection */
+    private $connection;
+
+
+    public function __construct(RabbitMQConnectionInfo $connectionInfo)
+    {
+        $this->info = $connectionInfo;
+
+        $this->logger = new SilentLogger();
+
+    }
+
+    public function setLogger(Logger $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function connect()
+    {
+        $this->channels = array();
+
+        if (!is_null($this->connection))
+            $this->disconnect();
+
+        $this->connection = new AMQPStreamConnection(
+            $this->info->getHost(),
+            $this->info->getPort(),
+            $this->info->getUsername(),
+            $this->info->getPassword(),
+            $this->info->getVHost()
+        );
+    }
+
+    public function disconnect()
+    {
+        if (!is_null($this->channels)) {
+            /** @var AMQPChannel $channel */
+            foreach ($this->channels as $channel)
+                $channel->close();
+        }
+
+        if (!is_null($this->connection))
+            $this->connection->close();
+
+        unset($this->channels);
+        unset($this->connection);
+    }
+
+    public function publish($channel, $queue, $message)
+    {
+        $ch = $this->getChannel($channel);
+
+        $ch->queue_declare($channel.".".$queue, false, false, false, false);
+
+        return $ch->basic_publish(new AMQPMessage($message), '', $channel.".".$queue);
+    }
+
+    public function consume($channel, $queue, callable $callback)
+    {
+        $ch = $this->getChannel($channel);
+
+        $ch->queue_declare($channel.".".$queue, false, false, false, false);
+
+        return $ch->basic_consume($channel.".".$queue, function($msg) use ($callback) {
+            $callback($msg->body);
+        });
+    }
+
+    public function hasCallbacks($channel)
+    {
+        $ch = $this->getChannel($channel);
+
+        return count($ch->callbacks);
+    }
+
+    public function wait($channel)
+    {
+        $ch = $this->getChannel($channel);
+
+        return $ch->wait();
+    }
+
+    /**
+     * @param $channel string
+     * @return AMQPChannel
+     */
+    private function getChannel($channel) {
+        if (array_key_exists($channel, $this->channels)) {
+            return $this->channels[$channel];
+        }
+
+        $ch = $this->connection->channel();
+
+        $this->channels[$channel] = $ch;
+
+        return $ch;
+    }
+}

--- a/vhs/messaging/exceptions/MessageQueueException.php
+++ b/vhs/messaging/exceptions/MessageQueueException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Thomas
+ * Date: 3/3/2016
+ * Time: 5:43 PM
+ */
+
+namespace vhs\messaging\exceptions;
+
+
+class MessageQueueException extends \Exception { }


### PR DESCRIPTION
This requires installing RabbitMQ on the server, setting it up with a user and vhost and also adding the config in the config.ini.php.

We also need to run composer.phar install during deploy to make sure we have the rabbitmq php library installed.