### PR TITLE
Add pagination controls to the admin/users page

### DIFF
--- a/app/contracts/IUserService1.php
+++ b/app/contracts/IUserService1.php
@@ -69,6 +69,13 @@ interface IUserService1 extends IContract {
     public function ListUsers($page, $size, $columns, $order, $filters);
 
     /**
+     * @permission administrator|grants
+     * @param $filters
+     * @return mixed
+     */
+    public function CountUsers($filters);
+
+    /**
      * @permission administrator|user
      * @param $userid
      * @return mixed

--- a/app/services/UserService.php
+++ b/app/services/UserService.php
@@ -322,12 +322,23 @@ class UserService extends Service implements IUserService1 {
         );
     }
 
+    public function AllowedColumns()
+    {
+        
+        if(CurrentUser::hasAnyPermissions("grants") && !CurrentUser::hasAnyPermissions("administrator"))
+            return ["id", "username", "fname", "lname", "email"];
+        else
+            return [];
+    }
+
     public function ListUsers($page, $size, $columns, $order, $filters)
     {
-        return User::page($page, $size, $columns, $order, $filters,
-            (CurrentUser::hasAnyPermissions("grants") && !CurrentUser::hasAnyPermissions("administrator")) ?
-            ["id", "username", "fname", "lname", "email"] : []
-        );
+        return User::page($page, $size, $columns, $order, $filters, $this->AllowedColumns());
+    }
+
+    public function CountUsers($filters)
+    {
+        return User::count($filters, $this->AllowedColumns());
     }
 
     /**

--- a/app/services/UserService.php
+++ b/app/services/UserService.php
@@ -328,7 +328,7 @@ class UserService extends Service implements IUserService1 {
         if(CurrentUser::hasAnyPermissions("grants") && !CurrentUser::hasAnyPermissions("administrator"))
             return ["id", "username", "fname", "lname", "email"];
         else
-            return [];
+            return null;
     }
 
     public function ListUsers($page, $size, $columns, $order, $filters)

--- a/vhs/domain/Domain.php
+++ b/vhs/domain/Domain.php
@@ -583,14 +583,14 @@ abstract class Domain extends Notifier implements IDomain, \Serializable, \JsonS
     /**
      * Constructs the WHERE clause for a filter expression
      * @param $filters
-     * @param array $allowed_columns either an array of strings containing the list of columns allowed in a filter expression or an empty list which means al columns are allowed
+     * @param array $allowed_columns either an array of strings containing the list of columns allowed in a filter expression or null which means al columns are allowed
      * @return array
      */
     
-    private static function constructFilterWhere($filters, array $allowed_columns) {
+    private static function constructFilterWhere($filters, array $allowed_columns = null) {
         $actualColumns = new Columns();
 
-        if(empty($allowed_columns)) {
+        if($allowed_columns == null) {
             // all table columns are allowed
             $actualColumns = self::Schema()->Columns();
         } else {

--- a/vhs/domain/Domain.php
+++ b/vhs/domain/Domain.php
@@ -437,6 +437,19 @@ abstract class Domain extends Notifier implements IDomain, \Serializable, \JsonS
         return $items;
     }
 
+    public static function doCount(Where $where = null) {
+        $class = get_called_class();
+
+        $records = Database::count(
+            Query::Count(
+                self::Schema()->Table(),
+                $where
+            )
+        );
+
+        return (int)$records;
+    }
+
     private static function arbitraryHydrate($sql) {
         $class = get_called_class();
 
@@ -488,6 +501,14 @@ abstract class Domain extends Notifier implements IDomain, \Serializable, \JsonS
         return self::hydrateMany($where, $orderBy, $limit, $offset);
     }
 
+
+
+    public static function count($filters, array $allowed_columns = null) {
+        $where = self::constructFilterWhere($filters, $allowed_columns);
+
+        return self::doCount($where);
+    }
+
     /**
      * Returns a key value pair of data from this domain
      * @param $page
@@ -523,11 +544,12 @@ abstract class Domain extends Notifier implements IDomain, \Serializable, \JsonS
                 );
         }
 
-        $actualColumns = new Columns();
+        /** @var OrderBy $orderBy */
+        $orderBy = array_pop($orderBys);
+        $orderBy->orderBy = $orderBys;
 
         foreach($columnNames as $col) {
             if (self::Schema()->Columns()->contains($col)) {
-                $actualColumns->add(self::Schema()->Columns()->getByName($col));
                 array_push($cols, $col);
             }
 
@@ -535,11 +557,8 @@ abstract class Domain extends Notifier implements IDomain, \Serializable, \JsonS
                 array_push($cols, $col);
         }
 
-        /** @var OrderBy $orderBy */
-        $orderBy = array_pop($orderBys);
-        $orderBy->orderBy = $orderBys;
 
-        $where = self::constructFilter($actualColumns, $filters);
+        $where = self::constructFilterWhere($filters, $allowed_columns);
 
         $objects = self::where($where, $orderBy, $size, $page);
 
@@ -562,6 +581,32 @@ abstract class Domain extends Notifier implements IDomain, \Serializable, \JsonS
     }
 
     /**
+     * Constructs the WHERE clause for a filter expression
+     * @param $filters
+     * @param array $allowed_columns either an array of strings containing the list of columns allowed in a filter expression or an empty list which means al columns are allowed
+     * @return array
+     */
+    
+    private static function constructFilterWhere($filters, array $allowed_columns) {
+        $actualColumns = new Columns();
+
+        if(empty($allowed_columns)) {
+            // all table columns are allowed
+            $actualColumns = self::Schema()->Columns();
+        } else {
+            // only some columns are allowed
+            foreach($allowed_columns as $col) {
+                if (self::Schema()->Columns()->contains($col)) {
+                    $actualColumns->add(self::Schema()->Columns()->getByName($col));
+                }
+            }
+        }
+
+        return self::constructFilter($actualColumns, $filters);
+    }
+
+
+    /**
      * Expects an object format like:
      * Expression {
      *   left: Expression,
@@ -570,7 +615,7 @@ abstract class Domain extends Notifier implements IDomain, \Serializable, \JsonS
      *   column: Column,
      *   value: Value
      * }
-     * @param Columns $columns
+     * @param Columns $columns the filters that are allowed to be used in the filter
      * @param $filter
      * @return null|Where
      */

--- a/web/admin/users/users.html
+++ b/web/admin/users/users.html
@@ -23,16 +23,13 @@
     </div>
 
     <div class="row">
+
+    </div>
+
+    <div class="row">
         <div class="col-lg-12">
 
             <div class="row">
-                <div class="col-lg-1">
-                    <label>Page</label> <input class="form-control" title="Page" type="text" ng-model="listService.page" ng-keyup="$event.keyCode == 13 && refresh()" />
-                </div>
-                <div class="col-lg-1">
-                    <label>Page Size</label> <input class="form-control" title="Page Size" type="text" ng-model="listService.size" ng-keyup="$event.keyCode == 13 && refresh()" />
-                </div>
-
                 <div class="col-lg-3">
                     <label>Columns</label> <input class="form-control" title="Columns" type="text" ng-model="listService.columns" ng-keyup="$event.keyCode == 13 && refresh()" />
                 </div>
@@ -87,6 +84,21 @@
             </div>
 
         </div>
+    </div>
+    <div class="row before-table">
+        <div class="col-md-7">
+            <pagination  ng-if="userCount" items-per-page="listService.pageSize" total-items="userCount" ng-model="listService.page" ng-change="refresh()" max-size="10" boundary-links="true" rotate="false" ></pagination>
+        </div>
+                <div class="col-md-2 inline-control">
+            <label>{{ userCount }} users found</label>
+        </div>
+        <div class="col-md-1 inline-control">
+            Page size: 
+            <select ng-model="listService.pageSize" ng-options="o for o in listService.allowedPageSizes" ng-change="refresh()"></select>
+        </div>
+
+
+    </div>
     </div>
 
         <p ng-if="!users.length">No users</p>

--- a/web/app.css
+++ b/web/app.css
@@ -68,3 +68,11 @@
     display: none !important;
     background-color: #f8f8f8;
 }
+
+.pagination {
+  margin: 0px;
+}
+
+.before-table {
+  margin-top: 20px;
+}

--- a/web/providers/user.js
+++ b/web/providers/user.js
@@ -12,6 +12,10 @@ angular
                 return $http.post("/services/web/UserService1.svc/ListUsers", {page: page, size: size, columns: columns, order: order, filters: filters})
                     .then(function(response) { return response.data; });
             },
+            CountUsers: function(filters) {
+                return $http.post("/services/web/UserService1.svc/CountUsers", {filters: filters})
+                    .then(function(response) { return response.data; });
+            },
             GetUser: function(userid) {
                 return $http.get("/services/web/UserService1.svc/GetUser?userid=" + userid)
                     .then(function(response) {


### PR DESCRIPTION
Adds pagination controls to the admin/users page. Uses the bootstrap pagination control to implement it.

In order to do this, a CountUsers function is added to the backend.

Filter expressions are no longer limited to filter only the visible columns. They are only limited to filter the columns that the current user is allowed to see.