### PR TITLE
#275 simplify new member query, remove by keyholder total widget

### DIFF
--- a/app/services/MetricService.php
+++ b/app/services/MetricService.php
@@ -263,25 +263,14 @@ class MetricService extends Service implements IMetricService1 {
      * @return int
      */
     public static function NewMemberCount($start, $end) {
-        $join = Join::Left(
-            PaymentSchema::Table(),
-            On::Where(
-                Where::Equal(PaymentSchema::Columns()->payer_email,
-                    UserSchema::Columns()->email)
-            )
-        );
-
         $query = Query::count(
             UserSchema::Table(),
             Where::_And(
                 Where::Equal(UserSchema::Columns()->active,"y"),
                 Where::GreaterEqual(UserSchema::Columns()->mem_expire, date('Y-m-d H:i:s')),
                 Where::LesserEqual(UserSchema::Columns()->created, date('Y-m-d 00:00:00', $end)),
-                Where::GreaterEqual(UserSchema::Columns()->created, date('Y-m-d 00:00:00', $start)),
-                Where::LesserEqual($join->table->columns->date, date('Y-m-d 00:00:00', $end)),
-                Where::GreaterEqual($join->table->columns->date, date('Y-m-d 00:00:00', $start)),
-                Where::Equal($join->table->columns->status, 1)
-            ))->Join($join);
+                Where::GreaterEqual(UserSchema::Columns()->created, date('Y-m-d 00:00:00', $start))
+            ));
 
         return Database::count($query);
     }
@@ -309,14 +298,6 @@ class MetricService extends Service implements IMetricService1 {
      * @return int
      */
     public static function NewMembershipByIdCount($membership_id, $start, $end) {
-        $join = Join::Left(
-            PaymentSchema::Table(),
-            On::Where(
-                Where::Equal(PaymentSchema::Columns()->payer_email,
-                    UserSchema::Columns()->email)
-            )
-        );
-
         $query = Query::count(
             UserSchema::Table(),
             Where::_And(
@@ -324,11 +305,8 @@ class MetricService extends Service implements IMetricService1 {
                 Where::GreaterEqual(UserSchema::Columns()->mem_expire, date('Y-m-d H:i:s')),
                 Where::Equal(UserSchema::Columns()->membership_id, $membership_id),
                 Where::LesserEqual(UserSchema::Columns()->created, date('Y-m-d 00:00:00', $end)),
-                Where::GreaterEqual(UserSchema::Columns()->created, date('Y-m-d 00:00:00', $start)),
-                Where::LesserEqual($join->table->columns->date, date('Y-m-d 00:00:00', $end)),
-                Where::GreaterEqual($join->table->columns->date, date('Y-m-d 00:00:00', $start)),
-                Where::Equal($join->table->columns->status, 1)
-            ))->Join($join);
+                Where::GreaterEqual(UserSchema::Columns()->created, date('Y-m-d 00:00:00', $start))
+            ));
 
         return Database::count($query);
     }

--- a/web/user/dashboard/dashboard.html
+++ b/web/user/dashboard/dashboard.html
@@ -27,7 +27,7 @@
                         </div>
                     </div>
                     <div class="panel-footer">
-                        <span class="pull-left">Last 30 Days</span>
+                        <span class="pull-left">Since {{newMembersSince}}</span>
                         <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
                         <div class="clearfix"></div>
                     </div>
@@ -54,49 +54,6 @@
                 </div>
             </div>
         </div>
-        <div class="row">
-            <div class="col-lg-6">
-                <div class="panel panel-yellow">
-                    <div class="panel-heading">
-                        <div class="row">
-                            <div class="col-xs-3">
-                                <i class="fa fa-key fa-5x"></i>
-                            </div>
-                            <div class="col-xs-9 text-right">
-                                <div class="huge">{{newKeyHolders.value}}</div>
-                                <div>New Key Holders!</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="panel-footer">
-                        <span class="pull-left">Last 30 Days</span>
-                        <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
-                        <div class="clearfix"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-lg-6">
-                <div class="panel panel-yellow">
-                    <div class="panel-heading">
-                        <div class="row">
-                            <div class="col-xs-3">
-                                <i class="fa fa-key fa-5x"></i>
-                            </div>
-                            <div class="col-xs-9 text-right">
-                                <div class="huge">{{totalKeyHolders.value}}</div>
-                                <div>Total Key Holders!</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="panel-footer">
-                        <span class="pull-left">{{date}}</span>
-                        <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
-                        <div class="clearfix"></div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
     </div>
 </div>
 

--- a/web/user/dashboard/dashboard.js
+++ b/web/user/dashboard/dashboard.js
@@ -17,14 +17,6 @@ angular
                         //if (!$rootScope.authenticated) throw "login";
                         return MetricService1.GetTotalMembers();
                     }],
-                    newKeyHolders: ['$rootScope', '$stateParams', 'MetricService1', function($rootScope, $stateParams, MetricService1) {
-                        //if (!$rootScope.authenticated) throw "login";
-                        return MetricService1.GetNewKeyHolders(moment().utc().subtract(30, "days").startOf('month').toISOString(), moment().utc().endOf('month').toISOString());
-                    }],
-                    totalKeyHolders: ['$rootScope', '$stateParams', 'MetricService1', function($rootScope, $stateParams, MetricService1) {
-                        //if (!$rootScope.authenticated) throw "login";
-                        return MetricService1.GetTotalKeyHolders();
-                    }],
                     allPermissions: ['$rootScope', 'PrivilegeService1', function($rootScope, PrivilegeService1) {
                         //if (!$rootScope.authenticated) throw "login";
                         return PrivilegeService1.GetAllPrivileges();
@@ -55,12 +47,11 @@ angular
                     }]
                 },
                 controller: [
-                    '$scope', 'newMembers', 'newKeyHolders', 'totalMembers', 'totalKeyHolders', 'revenue', 'members', 'revenueLastMonth', 'revenueThisMonth', 'createdDates', 'createdDatesLast30days',
-                    function($scope, newMembers, newKeyHolders, totalMembers, totalKeyHolders, revenue, members, revenueLastMonth, revenueThisMonth, createdDates, createdDatesLast30days) {
+                    '$scope', 'newMembers', 'totalMembers', 'revenue', 'members', 'revenueLastMonth', 'revenueThisMonth', 'createdDates', 'createdDatesLast30days',
+                    function($scope, newMembers, totalMembers, revenue, members, revenueLastMonth, revenueThisMonth, createdDates, createdDatesLast30days) {
                         $scope.newMembers = newMembers;
-                        $scope.newKeyHolders = newKeyHolders;
+                        $scope.newMembersSince = moment().utc().subtract(30, "days").startOf('month').format("MMM dd ");
                         $scope.totalMembers = totalMembers;
-                        $scope.totalKeyHolders = totalKeyHolders;
                         $scope.date = moment().format("MMMM YYYY");
                         $scope.revenue = revenue;
                         $scope.members = members;

--- a/web/user/dashboard/dashboard.js
+++ b/web/user/dashboard/dashboard.js
@@ -50,7 +50,7 @@ angular
                     '$scope', 'newMembers', 'totalMembers', 'revenue', 'members', 'revenueLastMonth', 'revenueThisMonth', 'createdDates', 'createdDatesLast30days',
                     function($scope, newMembers, totalMembers, revenue, members, revenueLastMonth, revenueThisMonth, createdDates, createdDatesLast30days) {
                         $scope.newMembers = newMembers;
-                        $scope.newMembersSince = moment().utc().subtract(30, "days").startOf('month').format("MMM dd ");
+                        $scope.newMembersSince = moment().utc().subtract(30, "days").startOf('month').format("MMM DD, YYYY");
                         $scope.totalMembers = totalMembers;
                         $scope.date = moment().format("MMMM YYYY");
                         $scope.revenue = revenue;


### PR DESCRIPTION
#275 
fixes the new member counting by ignoring payments and just looking at the user creation date and that they are valid + not expired.

show new members since date instead of last 30 days because that was misleading.

also removes the total new keyholders and total keyholders count on the top right of the dashboard as those numbers have effectively converged and all new members are "keyholders".