### PR TITLE
Small: fix the nomos slack channel referenced on the "get involved" page

### DIFF
--- a/web/user/getinvolved/getinvolved.html
+++ b/web/user/getinvolved/getinvolved.html
@@ -19,7 +19,7 @@
 
 <h3>Slack</h3>
 
-To coordinate development, get on #vha-nomos on Slack (a kind of web-based IRC). If you would like to request an invite to Slack:
+To coordinate development, get on #vhs-nomos on Slack (a kind of web-based IRC). If you would like to request an invite to Slack:
 
 <br /><br />
 

--- a/web/user/getinvolved/getinvolved.html
+++ b/web/user/getinvolved/getinvolved.html
@@ -19,7 +19,7 @@
 
 <h3>Slack</h3>
 
-To coordinate development, get on #nomos on Slack (a kind of web-based IRC). If you would like to request an invite to Slack:
+To coordinate development, get on #vha-nomos on Slack (a kind of web-based IRC). If you would like to request an invite to Slack:
 
 <br /><br />
 


### PR DESCRIPTION
changed "#nomos" to "#vhs-nomos"