### PR TITLE
Unbreak webhook service

### DIFF
--- a/webhooker/webhooker.js
+++ b/webhooker/webhooker.js
@@ -3,7 +3,7 @@
  */
 
 const bunyan = require('bunyan')
-const program = require('commander')
+const { program } = require('commander')
 
 const { settings: config } = require('./config.js')
 


### PR DESCRIPTION
fixes this restart loop. Looks like commander was updated and they changed the default import

```
Node.js v22.13.0

> webhooker@1.0.0 start
> node webhooker.js

/app/webhooker/webhooker.js:10
program.version('1.0.0').option('-c, --console', 'Run in non-daemon mode and output log to console').parse(process.argv)
        ^

TypeError: program.version is not a function
    at Object.<anonymous> (/app/webhooker/webhooker.js:10:9)
    at Module._compile (node:internal/modules/cjs/loader:1562:14)
    at Object..js (node:internal/modules/cjs/loader:1699:10)
    at Module.load (node:internal/modules/cjs/loader:1313:32)
    at Function._load (node:internal/modules/cjs/loader:1123:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:170:5)
    at node:internal/main/run_main_module:36:49

Node.js v22.13.0
```