### PR TITLE
Fix schema init and migration

### DIFF
--- a/vhs/migration/Backup.php
+++ b/vhs/migration/Backup.php
@@ -41,6 +41,8 @@ class Backup {
         $command[] = 'mysqldump';
         $command[] = "-u '" . $this->user . "'";
         $command[] = '-p' . $this->password;
+        $command[] = '--ssl=0';
+        $command[] = '--no-tablespaces';
         if ($do_host == true) {
             $command[] = '--host ' . $this->server;
         }

--- a/vhs/migration/Backup.php
+++ b/vhs/migration/Backup.php
@@ -42,7 +42,7 @@ class Backup {
         $command[] = "-u '" . $this->user . "'";
         $command[] = '-p' . $this->password;
         $command[] = '--ssl=0';
-        $command[] = '--no-tablespaces';
+        $command[] = '--no-tablespaces'; // workaround for breaking change introduced in minor mysql version - see https://dba.stackexchange.com/questions/271981/access-denied-you-need-at-least-one-of-the-process-privileges-for-this-ope
         if ($do_host == true) {
             $command[] = '--host ' . $this->server;
         }

--- a/vhs/migration/Migrator.php
+++ b/vhs/migration/Migrator.php
@@ -105,7 +105,7 @@ class Migrator {
 
             $script_path = $migrationsPath . '/' . $version . '/';
 
-            $command = 'mysql -u' . DB_USER . ' -p' . DB_PASS . ' ' . '-h ' . DB_SERVER . ' -D ' . DB_DATABASE . " < {$script_path}";
+            $command = 'mysql -u' . DB_USER . ' -p' . DB_PASS . ' ' . '-h ' . DB_SERVER . ' -D ' . DB_DATABASE . " --ssl=0 < {$script_path}";
 
             foreach ($scripts as $script) {
                 $this->logger->log('Executing: ' . $script);


### PR DESCRIPTION
Idk how this crept in here, but migrations weren't running, and schema wasn't being setup, because the mysql container has self-signed ssh keys. I've disabled key validation for migrations.

I've also fixed the backup task that runs on startup, my also disabling ssl, and then adding a workaround (--no-tablespaces) for this issue:

https://dba.stackexchange.com/questions/271981/access-denied-you-need-at-least-one-of-the-process-privileges-for-this-ope

This should not be a security risk because mysql and backend both run in docker containers on the same machine, and because this only happens once at startup.