### PR TITLE
"get involved!" -> "Community"

### DIFF
--- a/web/user/getinvolved/getinvolved.html
+++ b/web/user/getinvolved/getinvolved.html
@@ -68,4 +68,4 @@
 
 <h4>Slack</h4>
 
-<p>foo </p>
+<p> Check out the <code>#vhs-nomos</code>, <code>#vhs-it-ops</code>, and <code>#vhs-smartspace</code> channels on the VHS slack. </p>

--- a/web/user/getinvolved/getinvolved.html
+++ b/web/user/getinvolved/getinvolved.html
@@ -1,27 +1,24 @@
 <div class="row">
     <div class="col-lg-12">
-        <h1 class="page-header">Get involved!</h1>
+        <h1 class="page-header">VHS Community - get involved!</h1>
     </div>
     <!-- /.col-lg-12 -->
 </div>
 
-<p>Great, here's how you can help</p>
-<h3>Source Code</h3>
-<p>The code for this web app (Nomos) is located on Github:</p>
-<p><a href="https://github.com/vhs/nomos">https://github.com/vhs/nomos</a></p>
+<p> VHS is made up of lot of very wonderful humans. The more you connect with the community, the more VHS has to offer. </p>
 
-<h3>Development</h3>
+<p> Here are some ways to connect with the VHS community </p>
+
+<h3>Talk</h3>
 
 <p>
-    Check the <a href="https://github.com/vhs/nomos/wiki">Project GitHub wiki</a> for instructions on how to get started. Nomos testing is done with a
-    Vagrant file that automagically sets up a test VM with the proper settings.
+    VHS' central community hub is the web-based forum <a href="https://talk.vanhack.ca">Talk</a>. This is where longer-lived conversations,
+    information, and announcements go - posts here are available to all vhs members, and some sections are available to the general public!
 </p>
 
 <h3>Slack</h3>
 
-To coordinate development, get on #vhs-nomos on Slack (a kind of web-based IRC). If you would like to request an invite to Slack:
-
-<br /><br />
+<p> For more ephemeral discussions, join the VHS slack - a live chat web app. You can request an invite to Slack here: </p>
 
 <div class="row">
     <div class="col-lg-6">
@@ -54,3 +51,21 @@ To coordinate development, get on #vhs-nomos on Slack (a kind of web-based IRC).
         </div>
     </div>
 </div>
+
+<h3>Development</h3>
+
+<p>
+    VHS is built on lots of tech. Some custom, some off-the-shelf, all set up and kept running by members. If you're handy with php, node, devops, or
+    similar technologies, and want to help out:
+</p>
+
+<h4>Source code</h4>
+
+<p> The code for this web app (Nomos), and most of our other infrastructure, is located on Github: </p>
+<p>
+    <a href="https://github.com/vhs/nomos">https://github.com/vhs/nomos</a>
+</p>
+
+<h4>Slack</h4>
+
+<p>foo </p>

--- a/web/user/getinvolved/getinvolved.html
+++ b/web/user/getinvolved/getinvolved.html
@@ -7,13 +7,17 @@
 
 <p> VHS is made up of lot of very wonderful humans. The more you connect with the community, the more VHS has to offer. </p>
 
-<p> Here are some ways to connect with the VHS community </p>
+<p> Here are some ways to connect with the VHS community:</p>
 
 <h3>Talk</h3>
 
 <p>
     VHS' central community hub is the web-based forum <a href="https://talk.vanhack.ca">Talk</a>. This is where longer-lived conversations,
-    information, and announcements go - posts here are available to all vhs members, and some sections are available to the general public!
+    information, and announcements go - posts here are available to all VHS members, and some sections are available to the general public!
+</p>
+
+<p>
+    <a class="btn btn-primary" type="submit" href="https://talk.vanhack.ca">Join Talk</a>
 </p>
 
 <h3>Slack</h3>

--- a/web/user/user.html
+++ b/web/user/user.html
@@ -66,7 +66,7 @@
                     </li>
                     <li>
                         <a ui-sref="user.getinvolved" ng-class="{active: $state.is('user.getinvolved')}"
-                            ><i class="fa fa-tasks fa-fw"></i> Get Involved!</a
+                            ><i class="fa fa-tasks fa-fw"></i> Community</a
                         >
                     </li>
                     <li ng-if="currentUser.hasPermission('administrator')">


### PR DESCRIPTION
the get involved page always seemed like it was just about development, which might have stopped some cool people from joining the slack group and connecting! I fix.

<img width="3072" height="1728" alt="community" src="https://github.com/user-attachments/assets/bcc6c8b6-1dc4-446e-bbe1-3fa3bbd5c243" />
